### PR TITLE
Support for plugins

### DIFF
--- a/srctools/scripts/config.py
+++ b/srctools/scripts/config.py
@@ -122,7 +122,7 @@ def parse(path: Path) -> Tuple[
             raise ValueError('Config "plugins" value cannot have children.')
         assert isinstance(prop.value, str)
         
-        plugins.add(Plugin(prop.name, Path(prop.value)))
+        plugins.add(Plugin(prop.name, game_root / Path(prop.value)))
 
     return conf, game, fsys_chain, blacklist, plugins
 

--- a/srctools/scripts/config.py
+++ b/srctools/scripts/config.py
@@ -120,7 +120,7 @@ def parse(path: Path) -> Tuple[
     plugins = set()  # type: Set[Plugin]
 
     # find all the plugins and make plugin objects out of them
-    for prop in conf.get(Property, 'plugins'):  # type: Property\
+    for prop in conf.get(Property, 'plugins'):  # type: Property
         if prop.has_children():
             raise ValueError('Config "plugins" value cannot have children.')
         assert isinstance(prop.value, str)

--- a/srctools/scripts/plugin.py
+++ b/srctools/scripts/plugin.py
@@ -19,7 +19,7 @@ class Plugin:
         mod = module_from_spec(spec)
 
         logname = '.' + self.name
-        mod.LOGGER = get_logger(__name__ + logname, "plugin" + logname)
+        mod.__srctools_logger__ = get_logger(__name__ + logname, "plugin" + logname)
 
         spec.loader.exec_module(mod)
 

--- a/srctools/scripts/plugin.py
+++ b/srctools/scripts/plugin.py
@@ -6,8 +6,8 @@ from srctools.logger import get_logger
 LOGGER = get_logger(__name__)
 
 class Plugin:
-    def __init__(self, name: str, path: Path) -> None:
-        self.name = name
+    def __init__(self, path: Path) -> None:
+        self.name = path.stem
         self.path = path
 
     def load(self):

--- a/srctools/scripts/plugin.py
+++ b/srctools/scripts/plugin.py
@@ -6,21 +6,26 @@ from srctools.logger import get_logger
 LOGGER = get_logger(__name__)
 
 class Plugin:
+    """A plugin loaded by the postcompiler.
+
+    This loads a module, and gives it a logger at __srctools_logger__
+    """
     def __init__(self, path: Path) -> None:
-        self.name = path.stem
         self.path = path
 
     def load(self):
-        spec = spec_from_file_location(self.name, self.path)
+        name = self.path.stem
+        spec = spec_from_file_location(name, self.path)
 
         if not spec:
-            raise ValueError('Plugin {} not found at "{}"'.format(self.name, self.path))
+            raise ValueError('Plugin {} not found at "{}"'.format(name, self.path))
 
         mod = module_from_spec(spec)
 
-        logname = '.' + self.name
+        logname = '.' + name
+        #this logger is put into the plugin so it has a consistant log name of "plugin.<plugin name>"
         mod.__srctools_logger__ = get_logger(__name__ + logname, "plugin" + logname)
 
         spec.loader.exec_module(mod)
 
-        LOGGER.info('Loaded plugin "{}" ({})', self.name, self.path)
+        LOGGER.info('Loaded plugin "{}" ({})', name, self.path)

--- a/srctools/scripts/plugin.py
+++ b/srctools/scripts/plugin.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from importlib.util import spec_from_file_location, module_from_spec
+
+from srctools.logger import get_logger
+
+LOGGER = get_logger(__name__)
+
+class Plugin:
+    def __init__(self, name: str, path: Path) -> None:
+        self.name = name
+        self.path = path
+
+    def load(self):
+        spec = spec_from_file_location(self.name, self.path)
+
+        if not spec:
+            raise ValueError('Plugin {} not found at "{}"'.format(self.name, self.path))
+
+        mod = module_from_spec(spec)
+
+        logname = '.' + self.name
+        mod.LOGGER = get_logger(__name__ + logname, "plugin" + logname)
+
+        spec.loader.exec_module(mod)
+
+        LOGGER.info('Loaded plugin "{}" ({})', self.name, self.path)

--- a/srctools/scripts/plugin.py
+++ b/srctools/scripts/plugin.py
@@ -13,7 +13,7 @@ class Plugin:
     def __init__(self, path: Path) -> None:
         self.path = path
 
-    def load(self):
+    def load(self) -> None:
         name = self.path.stem
         spec = spec_from_file_location(name, self.path)
 

--- a/srctools/scripts/postcompiler.py
+++ b/srctools/scripts/postcompiler.py
@@ -58,7 +58,7 @@ def main(argv: List[str]) -> None:
 
     LOGGER.info("Map path is {}", path)
 
-    conf, game_info, fsys, pack_blacklist = config.parse(path)
+    conf, game_info, fsys, pack_blacklist, plugins = config.parse(path)
 
     fsys.open_ref()
 
@@ -94,6 +94,9 @@ def main(argv: List[str]) -> None:
     else:
         LOGGER.warning('No studiomdl path provided.')
         studiomdl_loc = None
+
+    for plugin in plugins:
+        plugin.load()
 
     run_transformations(vmf, fsys, packlist, bsp_file, game_info, studiomdl_loc)
 


### PR DESCRIPTION
This PR adds support for plugins. The plugins key of the config is used to set up paths where python files are loaded as plugins. These plugins are run right before BSP transformations are run, as they are intended to add custom transformations. Plugins are given a logger at `__srctools_logger__` with the name `plugin.<plugin name>` to allow for consistent logging that clearly marks the output as coming from a plugin.

Motivation: Plugins allow for custom BSP transformations without modifying the postcompiler code, or wrapping it in another program. It also allows multiple plugins to be used at once. Custom transformations allow for custom entities that are implemented in vscript to be easily used from hammer and be configured with keyvalues.