### PR TITLE
fix RecursionError in iter_bases

### DIFF
--- a/srctools/fgd.py
+++ b/srctools/fgd.py
@@ -1667,6 +1667,9 @@ class EntityDef:
         if not _done:
             _done = {self}
         for ent in self.bases:
+            if ent in _done:
+                continue
+
             _done.add(ent)
             yield ent
             yield from ent.iter_bases(_done)


### PR DESCRIPTION
When two base classes depend on each other in HammerAddons' unify_fgd, this causes a `RecursionError` in `fgd.EntityDef.iter_bases` before `fgd.FGD.sorted_ents` is reached, which throws a much more readable error when there is a base loop.

This PR fixes the `RecursionError`, allowing for the more readable exception to be thrown.