### PR TITLE
Fix false positives in base loop check

### DIFF
--- a/srctools/fgd.py
+++ b/srctools/fgd.py
@@ -1891,12 +1891,12 @@ class FGD:
             done.update(batch)
 
             # All the entities have a dependency on another.
-            if todo == deferred:
+            if deferred and todo.difference(batch) == deferred:
                 raise ValueError(
                     "Loop in bases! \n "
                     "Problematic entities: \n{}".format([
                         ent.classname
-                        for ent in todo
+                        for ent in deferred
                     ]))
 
             todo = deferred.difference(done)


### PR DESCRIPTION
In `fgd.FGD.sorted_ents`, there is a check that will throw an exception if there are entities based on each other in a loop. In some cases, this exception will be thrown when there is no loop. This PR fixes the check.

`todo` may contain entities that are already in `batch`. This PR changes the check so that it compares the entities in `todo` that are not in `batch`. It also checks that `deferred` is not empty.