### PR TITLE
Update readme's min Python version to 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ variety of tools using these.
 
 # Installation
 First clone the git repo to your computer. You'll likely want the `dev` branch, 
-a specific tag. You'll need Python 3.6+.
+a specific tag. You'll need Python 3.9+.
 
 Run the following to install dependencies:
 ```shell script


### PR DESCRIPTION
This repo now uses 3.9+ features in vtf.py as of https://github.com/TeamSpen210/srctools/commit/26df7164f1413ed96ce823c016bb8a5c03bb36b3, specifically this line: https://github.com/TeamSpen210/srctools/blob/29fa68270afd42f6054944ecf1976d678c7c4ddd/srctools/vtf.py#L82
Example of error using earlier versions: 
![image](https://user-images.githubusercontent.com/9014762/118946708-84e04080-b90b-11eb-9277-3ad9f1b5922d.png)

I believe this is the related PEP: https://www.python.org/dev/peps/pep-0585/