### PR TITLE
Use absolute path to create model directories

### DIFF
--- a/src/srctools/compiler/mdl_compiler.py
+++ b/src/srctools/compiler/mdl_compiler.py
@@ -82,7 +82,7 @@ class ModelCompiler(Generic[ModelKey, InT, OutT]):
     def __enter__(self) -> 'ModelCompiler[ModelKey, InT, OutT]':
         """Load the previously compiled models and prepare for compiles."""
         # Ensure the folder exists.
-        os.makedirs(self.model_folder, exist_ok=True)
+        os.makedirs(self.model_folder_abs, exist_ok=True)
         data: List[Tuple[ModelKey, str, OutT]]
         version = 0
         try:

--- a/src/srctools/compiler/mdl_compiler.py
+++ b/src/srctools/compiler/mdl_compiler.py
@@ -171,7 +171,7 @@ class ModelCompiler(Generic[ModelKey, InT, OutT]):
             * The args parameter, which can be anything. This is useful for
               passing data that can't be pickled, but the function still needs.
         It should create "mdl.qc" in the folder, and then
-        StudioMDL will be called on the model to comile it. The return value will
+        StudioMDL will be called on the model to compile it. The return value will
         be passed back from this function.
 
         If the model key is None, a new model will always be compiled.

--- a/src/srctools/compiler/propcombine.py
+++ b/src/srctools/compiler/propcombine.py
@@ -1109,7 +1109,7 @@ def combine(
             dump_vmf.export(f)
 
     LOGGER.info(
-        'Combined {} props into {}:\n - {} grouped models\n - {} ineligable\n - {} failed to combine',
+        'Combined {} props into {}:\n - {} grouped models\n - {} ineligible\n - {} failed to combine',
         prop_count,
         len(final_props),
         group_count,


### PR DESCRIPTION
Fixes unexpected behaviour (like traversing outside of the directory and throwing a permissions error) when compiling a .VMF from a path outside of `game/sdk_content/...`.