### PR TITLE
Fix log message formatting on python 3.10+

### DIFF
--- a/src/srctools/logger.py
+++ b/src/srctools/logger.py
@@ -140,6 +140,9 @@ class LoggerAdapter(logging.LoggerAdapter):  # type: ignore[type-arg]  # Only ge
             if sys.version_info >= (3, 8) and 'stacklevel' in kwargs:
                 log_args['stacklevel'] = kwargs.pop('stacklevel')
 
+            if sys.version_info >= (3, 10):
+                log_args['stacklevel'] = kwargs.get( 'stacklevel', 0 ) + 2
+
             # noinspection PyProtectedMember
             self.logger._log(
                 level,

--- a/src/srctools/logger.py
+++ b/src/srctools/logger.py
@@ -141,7 +141,7 @@ class LoggerAdapter(logging.LoggerAdapter):  # type: ignore[type-arg]  # Only ge
                 log_args['stacklevel'] = kwargs.pop('stacklevel')
 
             if sys.version_info >= (3, 10):
-                log_args['stacklevel'] = kwargs.get( 'stacklevel', 0 ) + 2
+                log_args['stacklevel'] = kwargs.get('stacklevel', 0) + 2
 
             # noinspection PyProtectedMember
             self.logger._log(

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,13 @@
+"""Import all modules, to ensure at least imports work."""
+import sys
+from io import StringIO
+
+
+def test_logging_output() -> None:
+    """Test the output of logging to the console."""
+    from srctools.logger import init_logging, get_logger
+    old, sys.stdout = sys.stdout, StringIO()
+    init_logging().info( 'hello there' )
+    output, sys.stdout = sys.stdout, old
+    output.seek(0)
+    assert output.read() == '[I] test_logger.test_logging_output(): hello there\n'

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -7,7 +7,7 @@ def test_logging_output() -> None:
     """Test the output of logging to the console."""
     from srctools.logger import init_logging, get_logger
     old, sys.stdout = sys.stdout, StringIO()
-    init_logging().info( 'hello there' )
+    init_logging().info('hello there')
     output, sys.stdout = sys.stdout, old
     output.seek(0)
     assert output.read() == '[I] test_logger.test_logging_output(): hello there\n'


### PR DESCRIPTION
And also add a test for it

closes #18 

tested on Python 3.11, 3.10 and 3.9 ( all 64bit )