### PR TITLE
Fix matrix inverse and add another test for it

### DIFF
--- a/src/srctools/_math_matrix.cpp
+++ b/src/srctools/_math_matrix.cpp
@@ -128,9 +128,9 @@ bool mat3_inverse(const mat3_t* in, mat3_t* out)
     }
 
     *out =
-    {omat[0][3], omat[0][4], omat[0][5],
-     omat[1][3], omat[1][4], omat[1][5],
-     omat[2][3], omat[2][4], omat[2][5]};
+    {mat[0][3], mat[0][4], mat[0][5],
+     mat[1][3], mat[1][4], mat[1][5],
+     mat[2][3], mat[2][4], mat[2][5]};
 
     return true;
 }

--- a/src/srctools/math.py
+++ b/src/srctools/math.py
@@ -1933,9 +1933,9 @@ class MatrixBase:
         cls: Type[MatrixT] = type(self)
         out = cls.__new__(cls)
 
-        out._aa, out._ab, out._ac = omat_r[0][0], omat_r[0][1], omat_r[0][2]
-        out._ba, out._bb, out._bc = omat_r[1][0], omat_r[1][1], omat_r[1][2]
-        out._ca, out._cb, out._cc = omat_r[2][0], omat_r[2][1], omat_r[2][2]
+        out._aa, out._ab, out._ac = mat_r[0][0], mat_r[0][1], mat_r[0][2]
+        out._ba, out._bb, out._bc = mat_r[1][0], mat_r[1][1], mat_r[1][2]
+        out._ca, out._cb, out._cc = mat_r[2][0], mat_r[2][1], mat_r[2][2]
 
         return out
 

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -240,6 +240,20 @@ def test_inverse_known(frozen_thawed_matrix: MatrixClass) -> None:
 
     assert_rot(invert, correct, type=frozen_thawed_matrix)
 
+    # Test for matrix with known inverse
+    mat[0, 0], mat[0, 1], mat[0, 2] = ( 0.0,  0.0, -1.0)
+    mat[1, 0], mat[1, 1], mat[1, 2] = (-1.0,  0.0,  0.0)
+    mat[2, 0], mat[2, 1], mat[2, 2] = ( 0.0,  1.0,  0.0)
+
+    correct[0, 0], correct[0, 1], correct[0, 2] = ( 0.0, -1.0,  0.0)
+    correct[1, 0], correct[1, 1], correct[1, 2] = ( 0.0,  0.0,  1.0)
+    correct[2, 0], correct[2, 1], correct[2, 2] = (-1.0,  0.0,  0.0)
+
+    to_invert = frozen_thawed_matrix(mat)
+    invert = to_invert.inverse()
+
+    assert_rot(invert, correct, type=frozen_thawed_matrix)
+
 
 def test_inverse_fail(frozen_thawed_matrix: MatrixClass) -> None:
     """Test the matrix inverse() method for known failure. """


### PR DESCRIPTION
I had a typo in here where I was copying off the unordered augment of the matrix. This correctly grabs the augment with the right ordering. Resolves Issue #23