### PR TITLE
Implement support for multiple databases (lzma)

### DIFF
--- a/src/srctools/fgd.py
+++ b/src/srctools/fgd.py
@@ -1542,6 +1542,10 @@ class EntityDef:
         :raises KeyError: If the classname is not found in the database.
         """
         databases = _load_engine_db()
+
+        if len(databases) == 1:
+            return deepcopy(databases[0].get_ent(classname))
+
         to_return = EntityDef(EntityTypes.BASE) # Create an empty to make pyright shut up, it will always get bound, if not keyerror is raised
         errored = False
         for dbase in databases: # Order is important here, overrides will occur if multiple are specified
@@ -1561,12 +1565,16 @@ class EntityDef:
     @classmethod
     def engine_classes(cls) -> AbstractSet[str]:
         """Return a set of known entity classnames, from the Hammer Addons database."""
-        # This is immutable, so we don't need to copy.
         classnames: set[str] = set()
         databases = _load_engine_db()
+
+        if len(databases) == 1: # Don't iterate when there's no need to check for other databases
+            return databases[0].get_classnames()
+        
         for dbase in databases:
             classnames |= dbase.get_classnames()
 
+        # This is immutable, so we don't need to copy.
         return frozenset(classnames)
 
     def __repr__(self) -> str:
@@ -2295,7 +2303,7 @@ class FGD:
         temp_FGD = FGD()
         databases = _load_engine_db()
 
-        if len(databases) == 0: # If there's only one there's no need to iterate again
+        if len(databases) == 1: # If there's only one there's no need to iterate again
             return deepcopy(databases[0].get_fgd())
 
         for dbase in databases:

--- a/src/srctools/fgd.py
+++ b/src/srctools/fgd.py
@@ -289,7 +289,7 @@ class HelperTypes(Enum):
         return self.name.startswith('EXT_')
 
 
-def _load_engine_db() -> _EngineDBProto:
+def _load_engine_db() -> list[_EngineDBProto]:
     """Load our engine database."""
     # It's pretty expensive to parse, so keep the original privately,
     # returning a deep-copy.

--- a/src/srctools/fgd.py
+++ b/src/srctools/fgd.py
@@ -291,6 +291,10 @@ class HelperTypes(Enum):
         """Is this an extension to the format?"""
         return self.name.startswith('EXT_')
 
+def AddDBPath(path: Path) -> None:
+    """Appends new paths to search for databases."""
+    global _ENGINE_DB_PATHS
+    _ENGINE_DB_PATHS.append(path)
 
 def _load_engine_db() -> list[_EngineDBProto]:
     """Load our engine database."""

--- a/src/srctools/fgd.py
+++ b/src/srctools/fgd.py
@@ -1541,7 +1541,6 @@ class EntityDef:
 
         :raises KeyError: If the classname is not found in the database.
         """
-        to_return = KeyError()
         databases = _load_engine_db()
         for dbase in databases: # Order is important here, overrides will occur if multiple are specified
             to_return = deepcopy(dbase.get_ent(classname)) # Try to catch the entity from this database, if not, raises KeyError

--- a/src/srctools/fgd.py
+++ b/src/srctools/fgd.py
@@ -1547,6 +1547,9 @@ class EntityDef:
             
             if to_return is not KeyError:
                 break
+
+        else:
+            raise RuntimeError("No databases has been loaded!")
  
         return to_return
 

--- a/src/srctools/fgd.py
+++ b/src/srctools/fgd.py
@@ -1562,7 +1562,7 @@ class EntityDef:
     def engine_classes(cls) -> AbstractSet[str]:
         """Return a set of known entity classnames, from the Hammer Addons database."""
         # This is immutable, so we don't need to copy.
-        classnames = set()
+        classnames: set[str] = set()
         databases = _load_engine_db()
         for dbase in databases:
             classnames |= dbase.get_classnames()

--- a/src/srctools/fgd.py
+++ b/src/srctools/fgd.py
@@ -1542,14 +1542,15 @@ class EntityDef:
         :raises KeyError: If the classname is not found in the database.
         """
         databases = _load_engine_db()
+        if len(databases) == 0:
+            raise RuntimeError("No databases has been loaded!")
+        
         for dbase in databases: # Order is important here, overrides will occur if multiple are specified
             to_return = deepcopy(dbase.get_ent(classname)) # Try to catch the entity from this database, if not, raises KeyError
             
             if to_return is not KeyError:
                 break
 
-        else:
-            raise RuntimeError("No databases has been loaded!")
  
         return to_return
 

--- a/src/srctools/fgd.py
+++ b/src/srctools/fgd.py
@@ -2294,6 +2294,10 @@ class FGD:
         """
         temp_FGD = FGD()
         databases = _load_engine_db()
+
+        if len(databases) == 0: # If there's only one there's no need to iterate again
+            return deepcopy(databases[0].get_fgd())
+
         for dbase in databases:
             dbasefgd: FGD = dbase.get_fgd()
             for classname_, ent_ in dbasefgd.entities.items():

--- a/src/srctools/fgd.py
+++ b/src/srctools/fgd.py
@@ -314,7 +314,8 @@ def _engine_db_stats() -> str:
         to_return = ""
         for db in _ENGINE_DB:
             to_return += f"[Database {i}]: \n"
-            to_return += db.stats() + "\n"
+            to_return += db.stats()
+            i += 1
 
         return to_return
 

--- a/src/srctools/fgd.py
+++ b/src/srctools/fgd.py
@@ -288,16 +288,15 @@ class HelperTypes(Enum):
         """Is this an extension to the format?"""
         return self.name.startswith('EXT_')
 
-def AddDatabase(path: Path) -> None:
-    """Add a new database on top of the current ones."""
-    global _ENGINE_DB
 
-    if _ENGINE_DB is None:
-        _load_engine_db() # Ensure the first database is initialized and loaded
+def add_engine_database(path: Path) -> None:
+    """Add an additional binary database. This can override the existing entities."""
+    db = _load_engine_db()  # Ensure the first database is initialised and loaded
 
     with path.open('rb') as f:
         from ._engine_db import unserialise
-        _ENGINE_DB.insert(0, unserialise(f))
+        db.insert(0, unserialise(f))
+
 
 def _load_engine_db() -> list[_EngineDBProto]:
     """Load our engine database."""
@@ -307,8 +306,6 @@ def _load_engine_db() -> list[_EngineDBProto]:
     if _ENGINE_DB is None:
         _ENGINE_DB = []
         from ._engine_db import unserialise
-
-
 
         # On 3.8, importlib_resources doesn't have the right stubs.
         with cast(Any, files(srctools) / 'fgd.lzma').open('rb') as f:


### PR DESCRIPTION
Support for defining multiple databases.

To define another database to pull from, invoke AddDatabase() with a path object from pathutil as the argument.
Note: once the database is loaded invoking AddDatabase() won't add another one, it will get omitted.